### PR TITLE
Fix V3127

### DIFF
--- a/NFComm/NFKernelPlugin/Object/NFCRecord.cs
+++ b/NFComm/NFKernelPlugin/Object/NFCRecord.cs
@@ -296,7 +296,7 @@ namespace NFrame
 	            }
 	            if (mhtRecordVec.ContainsKey(nTargetRow))
 	            {
-	                valueTargetList = (NFIDataList)mhtRecordVec[nOriginRow];
+	                valueTargetList = (NFIDataList)mhtRecordVec[nTargetRow];
 	            }
 	
 	            if (null == valueTargetList)


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bugs, found using PVS-Studio:

- V3127 Two similar code fragments were found. Perhaps, this is a typo and 'nTargetRow' variable should be used instead of 'nOriginRow' NFCRecord.cs 299